### PR TITLE
feat: transition with new duration and instantaneous transitions

### DIFF
--- a/examples/iced-demo/Cargo.toml
+++ b/examples/iced-demo/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 iced = { branch = "master", git = "https://github.com/iced-rs/iced", features = [
     "canvas",
 ] }
-iced-animator = { path = "../../" }
+lilt = { path = "../../" }
 iced_futures = "0.12.0"

--- a/examples/iced-minimal/Cargo.toml
+++ b/examples/iced-minimal/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "iced-demo"
+name = "iced-minimal"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-iced = "0.12.1"
-iced-animator = { path = "../../" }
+iced = { branch = "master", git = "https://github.com/iced-rs/iced"  }
+lilt = { path = "../../" }
 iced_futures = "0.12.0"

--- a/src/animated.rs
+++ b/src/animated.rs
@@ -100,6 +100,13 @@ where
             .transition(new_value.float_value(), at, Some(new_duration_ms));
         self.value = new_value
     }
+    /// Updates the wrapped states and set the animation at its very end
+    pub fn transition_instantaneous(&mut self, new_value: T, at: Time) {
+        let mut at = at;
+        at.sub_ms(self.animation.duration_ms as u64);
+        self.animation.transition(new_value.float_value(), at, None);
+        self.value = new_value
+    }
     /// Returns whether the animation is complete, given the current time
     pub fn in_progress(&self, time: Time) -> bool {
         self.animation.in_progress(time)

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,14 +1,27 @@
 /// An interface for interacting with time.
 pub trait AnimationTime: Copy + std::fmt::Debug + Send {
     fn elapsed_since(self, time: Self) -> f32;
+    fn sub_ms(&mut self, duration_ms: u64);
+    fn add_ms(&mut self, duration_ms: u64);
 }
 
 impl AnimationTime for std::time::Instant {
     fn elapsed_since(self, time: Self) -> f32 {
         (self - time).as_millis() as f32
     }
-}
 
+    fn sub_ms(&mut self, duration_ms: u64) {
+        if let Some(instant) = self.checked_sub(std::time::Duration::from_millis(duration_ms)) {
+            *self = instant
+        }
+    }
+
+    fn add_ms(&mut self, duration_ms: u64) {
+        if let Some(instant) = self.checked_add(std::time::Duration::from_millis(duration_ms)) {
+            *self = instant
+        }
+    }
+}
 /// Defines a float representation for arbitrary types
 ///
 /// The actual float values are pretty arbitrary - as interpolation from


### PR DESCRIPTION
Hi!

First and foremost, thanks for this crate, it's quite ergonomic and it very helpful to simplify the code in my attempt to bring default animations to Iced core!
I just needed to add two methods:
- `transition_with_new_duration`: is helpful to change an animation duration while preserving the current progress. I use it to have different transition speeds on hover enter and exit for buttons, for instance
- `transition_instantaneous` is helpful to be able to reset transitions without changing the saved duration.

I've also fixed some clippy warnings and some inconsistencies in the examples in separate commits.

Thanks !