### PR TITLE
fix: reset `transition` on instantaneous transition

### DIFF
--- a/src/animated.rs
+++ b/src/animated.rs
@@ -209,6 +209,7 @@ where
     fn transition(&mut self, destination: f32, time: Time, instantaneous: bool) {
         if instantaneous {
             self.origin = destination;
+            self.transition = None;
             return;
         }
         let interrupted = *self;


### PR DESCRIPTION
Hi!

Thanks for the latest changes, it simplified my code even more 😁 
Just a quick fix here. Without it, grabbing and moving the scrollbar in an animated Iced scrollable makes the scrollbar bounce back to its starting point.

Thanks!