### PR TITLE
fix: transition over update and instantaneous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "lilt"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "iced",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lilt"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "A simple, dependency free library for running interruptable, transition based animations as a function of time."
 repository = "https://github.com/ejjonny/lilt"

--- a/examples/iced-indicator/src/main.rs
+++ b/examples/iced-indicator/src/main.rs
@@ -12,6 +12,7 @@ use iced::{
 use iced::{Element, Length, Theme};
 use lilt::{Animated, FloatRepresentable};
 use lilt::{Easing, Interpolable};
+use std::default::Default;
 use std::f32::consts::PI;
 use std::time::{Duration, Instant};
 
@@ -159,8 +160,10 @@ impl Example {
             .color;
 
         let height = 150.;
-        let mut font = Font::default();
-        font.weight = Weight::Bold;
+        let font = Font {
+            weight: Weight::Bold,
+            ..Default::default()
+        };
         let warn_icon = svg(svg::Handle::from_memory(include_bytes!(
             "../resources/warn.svg"
         )));
@@ -340,15 +343,14 @@ impl Example {
                                     .align_items(iced::Alignment::Center)
                                     .spacing(height * 0.2),
                             )
-                            .style(move |_| {
-                                let mut style = iced::widget::container::Style::default();
-                                style.border = Border {
+                            .style(move |_| iced::widget::container::Style {
+                                border: Border {
                                     color: Color::BLACK,
                                     width: 0.,
                                     radius: [height * 0.5; 4].into(),
-                                };
-                                style.background = Some(Background::Color(capsule_color));
-                                return style;
+                                },
+                                background: Some(Background::Color(capsule_color)),
+                                ..Default::default()
                             })
                             .height(Length::Fixed(height))
                             .width(Length::Shrink),
@@ -358,10 +360,9 @@ impl Example {
                 )
                 .padding(30.),
         ))
-        .style(move |_| {
-            let mut style = iced::widget::container::Style::default();
-            style.background = Some(Background::Color(Color::WHITE));
-            return style;
+        .style(move |_| iced::widget::container::Style {
+            background: Some(Background::Color(Color::WHITE)),
+            ..Default::default()
         })
         .fill()
         .into()

--- a/src/animated.rs
+++ b/src/animated.rs
@@ -137,7 +137,9 @@ where
     }
     /// Updates the wrapped state & begins an animation
     pub fn transition(&mut self, new_value: T, at: Time) {
-        self.last_value = self.value;
+        if self.value != new_value {
+            self.last_value = self.value;
+        }
         self.value = new_value;
         self.animation
             .transition(new_value.float_value(), at, false)


### PR DESCRIPTION
Hi!

I didn't notice at first but some of the latest commits broke the scrollbar in Iced animations.
Basically there were two issues:
- instantaneous transitions did not update the value anymore, which ended in grabbing the scrollbar not doing anything (sorry, the exact fix for this got mixed up in the "fix clippy warnings" commit, I just noticed)
- the new logic in `transition` resulted in the animation being accelerated when many calls to `transitions` were made for the same target value. In the scrollbar, it would make the scrolling speed increase when hitting the start or the end while spamming the mouse wheel. Although I guess it could have been fixed on the Iced side, I think it's nice to have a consistent and predictable animation speed in lilt.

Apart from that, I fixed some clippy warnings and added a requirement for `Interpolable` to implement `Copy`. While cloning values can in some cases be as inexpensive as copying them, I think having that requirement is important to ensure transition calculations remain fast.

Thanks!