### PR TITLE
add optional wasm feature with web-time dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,6 +3311,7 @@ dependencies = [
  "gpui",
  "iced",
  "macroquad",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ authors = ["ejjonny"]
 [lib]
 crate-type = ["lib"]
 
+[features]
+wasm = ["dep:web-time"]
+
 [[example]]
 name = "iced-minimal"
 path = "examples/iced-minimal/src/main.rs"
@@ -41,3 +44,6 @@ macroquad = "0.4.13"
 
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 gpui = { git = "https://github.com/zed-industries/zed", rev = "5b1ea7eda0bba40e222f7d904ec65e5848f45eee" }
+
+[dependencies]
+web-time = { version = "1.1.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,6 @@ authors = ["ejjonny"]
 [lib]
 crate-type = ["lib"]
 
-[features]
-# If feature is enabled the implementation of `AnimationTime` is switched from `std::time::Instant` to `web-time::Instant`.
-wasm = ["dep:web-time"]
-
 [[example]]
 name = "iced-minimal"
 path = "examples/iced-minimal/src/main.rs"
@@ -47,4 +43,4 @@ macroquad = "0.4.13"
 gpui = { git = "https://github.com/zed-industries/zed", rev = "5b1ea7eda0bba40e222f7d904ec65e5848f45eee" }
 
 [dependencies]
-web-time = { version = "1.1.0", optional = true }
+web-time = "1.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["ejjonny"]
 crate-type = ["lib"]
 
 [features]
+# If feature is enabled the implementation of `AnimationTime` is switched from `std::time::Instant` to `web-time::Instant`.
 wasm = ["dep:web-time"]
 
 [[example]]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,14 +3,6 @@ pub trait AnimationTime: Copy + std::fmt::Debug + Send {
     fn elapsed_since(self, time: Self) -> f32;
 }
 
-#[cfg(not(feature = "wasm"))]
-impl AnimationTime for std::time::Instant {
-    fn elapsed_since(self, time: Self) -> f32 {
-        (self - time).as_millis() as f32
-    }
-}
-
-#[cfg(feature = "wasm")]
 impl AnimationTime for web_time::Instant {
     fn elapsed_since(self, time: Self) -> f32 {
         (self - time).as_millis() as f32

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,7 +3,15 @@ pub trait AnimationTime: Copy + std::fmt::Debug + Send {
     fn elapsed_since(self, time: Self) -> f32;
 }
 
+#[cfg(not(feature = "wasm"))]
 impl AnimationTime for std::time::Instant {
+    fn elapsed_since(self, time: Self) -> f32 {
+        (self - time).as_millis() as f32
+    }
+}
+
+#[cfg(feature = "wasm")]
+impl AnimationTime for web_time::Instant {
     fn elapsed_since(self, time: Self) -> f32 {
         (self - time).as_millis() as f32
     }


### PR DESCRIPTION
This PR adds an optional wasm feature. This feature is optional. If it is active the implementation of `AnimationTime` is switched from std::time::Instant to web-time::Instant.

As background. This PR is supposed to fix an issue in the iced dev branch which utilities lilt and can not compile to wasm as of now.